### PR TITLE
Adds FailIfLocked acquire lock option

### DIFF
--- a/client.go
+++ b/client.go
@@ -208,6 +208,13 @@ func ReplaceData() AcquireLockOption {
 	}
 }
 
+// FailIfLocked will not retry to acquire the lock, instead returning.
+func FailIfLocked() AcquireLockOption {
+	return func(opt *acquireLockOptions) {
+		opt.failIfLocked = true
+	}
+}
+
 // WithDeleteLockOnRelease defines whether or not the lock should be deleted
 // when Close() is called on the resulting LockItem will force the new content
 // to be stored in the key.
@@ -332,7 +339,6 @@ func (c *Client) acquireLock(opt *acquireLockOptions) (*Lock, error) {
 	}
 
 	for {
-
 		c.logger.Println("Call GetItem to see if the lock for ",
 			c.partitionKeyName, " =", key, ", ",
 			aws.StringValue(c.sortKeyName), "=", sortKey,
@@ -391,6 +397,12 @@ func (c *Client) acquireLock(opt *acquireLockOptions) (*Lock, error) {
 			 * Someone else has the lock, and they have the lock for LEASE_DURATION time. At this point, we need
 			 * to wait at least LEASE_DURATION milliseconds before we can try to acquire the lock.
 			 */
+
+			// If the user has set `FailIfLocked` option, exit after the first attempt to acquire the lock.
+			if opt.failIfLocked {
+				return nil, &LockNotGrantedError{"Didn't acquire lock because it is locked and request is configured not to retry."}
+			}
+
 			lockTryingToBeAcquired = existingLock
 			if !alreadySleptOnceForOneLeasePeriod {
 				alreadySleptOnceForOneLeasePeriod = true

--- a/structs.go
+++ b/structs.go
@@ -28,6 +28,7 @@ type acquireLockOptions struct {
 	data                        []byte
 	replaceData                 bool
 	deleteLockOnRelease         bool
+	failIfLocked                bool
 	refreshPeriod               time.Duration
 	additionalTimeToWaitForLock time.Duration
 	additionalAttributes        map[string]*dynamodb.AttributeValue


### PR DESCRIPTION
In my application I am using a fixed worker pool that read from AWS SQS. The blocking operation for a worker in the pool is very bad for the overall throughput of the system, and I can safely return if the lock is taken by another process and rely on the SQS message becoming visible again the queue as the retry.

I'm unable to build your project:

```
lromanovsky:(lr/fail-if-locked)~/go/src/github.com/ucirello/dynamolock$ go build
can't load package: package github.com/ucirello/dynamolock: code in directory /home/lromanovsky/go/src/github.com/ucirello/dynamolock expects import "cirello.io/dynamolock"
```

Is there an environmental configuration that I am missing?
